### PR TITLE
Allows players to re-open the mapvote UI

### DIFF
--- a/lua/mapvote/cl_mapvote.lua
+++ b/lua/mapvote/cl_mapvote.lua
@@ -108,7 +108,7 @@ function PANEL:Init()
     end
 
     self.closeButton.DoClick = function()
-        print("HI")
+        chat.AddText("To re-open the map vote, type !openmapvote")
         self:SetVisible(false)
     end
 
@@ -333,8 +333,12 @@ function PANEL:Paint()
     surface.DrawRect(0, 0, ScrW(), ScrH())
 end
 
-function PANEL:Flash(id)
+function PANEL:Show()
     self:SetVisible(true)
+end
+
+function PANEL:Flash(id)
+    self:Show()
 
     local bar = self:GetMapButton(id)
     
@@ -349,3 +353,13 @@ function PANEL:Flash(id)
 end
 
 derma.DefineControl("RAM_VoteScreen", "", PANEL, "DPanel")
+
+
+net.Receive("RAM_MapVoteOpenUI", function()
+    if(IsValid(MapVote.Panel) == false) then
+        chat.AddText("You can only use this command when a mapvote in progress.")
+        return
+    end
+
+    MapVote.Panel:Show()
+end)

--- a/lua/mapvote/sv_mapvote.lua
+++ b/lua/mapvote/sv_mapvote.lua
@@ -1,6 +1,7 @@
 util.AddNetworkString("RAM_MapVoteStart")
 util.AddNetworkString("RAM_MapVoteUpdate")
 util.AddNetworkString("RAM_MapVoteCancel")
+util.AddNetworkString("RAM_MapVoteOpenUI")
 util.AddNetworkString("RTV_Delay")
 
 MapVote.Continued = false
@@ -214,3 +215,12 @@ function MapVote.Cancel()
         timer.Destroy("RAM_MapVote")
     end
 end
+
+
+hook.Remove("PlayerSay", "mapvote_playersay")
+hook.Add("PlayerSay", "mapvote_playersay", function(ply, text)
+    if(string.lower(text) != "!openmapvote") then return end
+
+    net.Start("RAM_MapVoteOpenUI")
+    net.Send(ply)
+end)


### PR DESCRIPTION
Allows players to type `!openmapvote` during a map vote to re-open the voting interface.

When a player closes the voting interface, the following message appears in their chat:
`To re-open the map vote, type !openmapvote`